### PR TITLE
add swap-id command

### DIFF
--- a/binance/address.go
+++ b/binance/address.go
@@ -1,0 +1,46 @@
+package binance
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/tendermint/tendermint/libs/bech32"
+)
+
+const Prefix = "bnb"
+
+type AccAddress []byte
+
+func (bz AccAddress) String() string {
+	bech32Addr, err := bech32.ConvertAndEncode(Prefix, bz)
+	if err != nil {
+		panic(err)
+	}
+	return bech32Addr
+}
+
+// AccAddressFromBech32 to create an AccAddress from a bech32 string
+func AccAddressFromBech32(address string) (addr AccAddress, err error) {
+	bz, err := GetFromBech32(address, Prefix)
+	if err != nil {
+		return nil, err
+	}
+	return AccAddress(bz), nil
+}
+
+// GetFromBech32 to decode a bytestring from a bech32-encoded string
+func GetFromBech32(bech32str, prefix string) ([]byte, error) {
+	if len(bech32str) == 0 {
+		return nil, errors.New("decoding bech32 address failed: must provide an address")
+	}
+	hrp, bz, err := bech32.DecodeAndConvert(bech32str)
+	if err != nil {
+		return nil, err
+	}
+
+	if hrp != prefix {
+		return nil, fmt.Errorf("invalid bech32 prefix. Expected %s, Got %s", prefix, hrp)
+	}
+
+	return bz, nil
+}

--- a/binance/swap.go
+++ b/binance/swap.go
@@ -1,0 +1,15 @@
+package binance
+
+import (
+	"strings"
+
+	"github.com/tendermint/tendermint/crypto/tmhash"
+)
+
+func CalculateSwapID(randomNumberHash []byte, sender AccAddress, senderOtherChain string) []byte {
+	senderOtherChain = strings.ToLower(senderOtherChain)
+	data := randomNumberHash
+	data = append(data, []byte(sender)...)
+	data = append(data, []byte(senderOtherChain)...)
+	return tmhash.Sum(data)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ func Execute() error {
 	rootCmd.AddCommand(MonikersCmd(cdc))
 	rootCmd.AddCommand(LaunchBlameCmd(cdc))
 	rootCmd.AddCommand(SubscribeCmd(cdc))
+	rootCmd.AddCommand(SwapIDCmd(cdc))
 
 	return rootCmd.Execute()
 }

--- a/cmd/swap-id.go
+++ b/cmd/swap-id.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/kava-labs/kava/x/bep3/types"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	"github.com/kava-labs/kvtool/binance"
+)
+
+// SwapIDCmd returns a command to calculate a bep3 swap ID for binance and kava chains.
+func SwapIDCmd(cdc *codec.Codec) *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "swap-id [random number hash] [non deputy address]",
+		Short: "Calculate the binance and kava swap IDs given swap details.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+
+			// get deputy addresses
+			kavaDeputy, err := sdk.AccAddressFromBech32("kava1r4v2zdhdalfj2ydazallqvrus9fkphmglhn6u6")
+			if err != nil {
+				panic(err.Error())
+			}
+			bnbDeputy, err := binance.AccAddressFromBech32("bnb1jh7uv2rm6339yue8k4mj9406k3509kr4wt5nxn")
+			if err != nil {
+				panic(err.Error())
+			}
+
+			randomNumberHash, err := hex.DecodeString(args[0])
+			if err != nil {
+				return err
+			}
+
+			// try and decode the bech32 address as either kava or bnb
+			addressKava, errKava := sdk.AccAddressFromBech32(args[1])
+			addressBnb, errBnb := binance.AccAddressFromBech32(args[1])
+
+			// fail if both decoding failed
+			isKavaAddress := errKava == nil && errBnb != nil
+			isBnbAddress := errKava != nil && errBnb == nil
+			if !isKavaAddress && !isBnbAddress {
+				return fmt.Errorf("can't unmarshal input address as either kava or bnb: (%s) (%s)", errKava.Error(), errBnb.Error())
+			}
+
+			// calculate swap IDs
+			var swapIDKava, swapIDBnb []byte
+			if isKavaAddress {
+				if addressKava.Equals(kavaDeputy) {
+					return fmt.Errorf("input address cannot be deputy address: %s", kavaDeputy)
+				}
+				swapIDKava = types.CalculateSwapID(randomNumberHash, addressKava, bnbDeputy.String())
+				swapIDBnb = binance.CalculateSwapID(randomNumberHash, bnbDeputy, addressKava.String())
+			} else {
+				if bytes.Equal(addressBnb, bnbDeputy) {
+					return fmt.Errorf("address cannot be deputy address %s", bnbDeputy)
+				}
+				swapIDBnb = binance.CalculateSwapID(randomNumberHash, addressBnb, kavaDeputy.String())
+				swapIDKava = types.CalculateSwapID(randomNumberHash, kavaDeputy, addressBnb.String())
+			}
+
+			// print out result
+			result := struct {
+				KavaID string
+				BnbID  string
+			}{
+				KavaID: hex.EncodeToString(swapIDKava),
+				BnbID:  hex.EncodeToString(swapIDBnb),
+			}
+			bz, err := yaml.Marshal(result)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(bz))
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/kava-labs/kvtool
 go 1.13
 
 require (
+	github.com/btcsuite/btcd v0.20.1-beta // indirect
 	github.com/cosmos/cosmos-sdk v0.38.4
 	github.com/kava-labs/kava v0.8.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.0 // indirect
 	github.com/tendermint/tendermint v0.33.3
+	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -53,9 +53,13 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/btcsuite/btcd v0.0.0-20190115013929-ed77733ec07d h1:xG8Pj6Y6J760xwETNmMzmlt38QSwz0BLp1cZ09g27uw=
 github.com/btcsuite/btcd v0.0.0-20190115013929-ed77733ec07d/go.mod h1:d3C0AkH6BRcvO8T0UEPu53cnw4IbV63x1bEjildYhO0=
+github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
+github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20180706230648-ab6388e0c60a h1:RQMUrEILyYJEoAT34XS/kLu40vC0+po/UfxrBBA4qZE=
 github.com/btcsuite/btcutil v0.0.0-20180706230648-ab6388e0c60a/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d h1:yJzD/yFppdVCf6ApMkVy8cUxV0XrxdP9rVf6D87/Mng=
+github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
@@ -445,7 +449,6 @@ github.com/tendermint/iavl v0.13.2/go.mod h1:vE1u0XAGXYjHykd4BLp8p/yivrw2PF1Tuol
 github.com/tendermint/tendermint v0.33.2/go.mod h1:25DqB7YvV1tN3tHsjWoc2vFtlwICfrub9XO6UBO+4xk=
 github.com/tendermint/tendermint v0.33.3 h1:6lMqjEoCGejCzAghbvfQgmw87snGSqEhDTo/jw+W8CI=
 github.com/tendermint/tendermint v0.33.3/go.mod h1:25DqB7YvV1tN3tHsjWoc2vFtlwICfrub9XO6UBO+4xk=
-github.com/tendermint/tendermint v0.33.5 h1:jYgRd9ImkzA9iOyhpmgreYsqSB6tpDa6/rXYPb8HKE8=
 github.com/tendermint/tm-db v0.4.1/go.mod h1:JsJ6qzYkCGiGwm5GHl/H5GLI9XLb6qZX7PRe425dHAY=
 github.com/tendermint/tm-db v0.5.0 h1:qtM5UTr1dlRnHtDY6y7MZO5Di8XAE2j3lc/pCnKJ5hQ=
 github.com/tendermint/tm-db v0.5.0/go.mod h1:lSq7q5WRR/njf1LnhiZ/lIJHk2S8Y1Zyq5oP/3o9C2U=


### PR DESCRIPTION
Add a swap-id command to easily calculate what a swap's ID will be on both kava and binance, given the original sender's address.