### PR TITLE
Add kava-4 deputies to swap-id cmd

### DIFF
--- a/cmd/swap-id.go
+++ b/cmd/swap-id.go
@@ -14,35 +14,46 @@ import (
 	"github.com/kava-labs/kvtool/binance"
 )
 
+var (
+	kavaDeputiesStrings map[string]string = map[string]string{
+		"bnb":  "kava1r4v2zdhdalfj2ydazallqvrus9fkphmglhn6u6",
+		"btcb": "kava14qsmvzprqvhwmgql9fr0u3zv9n2qla8zhnm5pc",
+		"busd": "kava1hh4x3a4suu5zyaeauvmv7ypf7w9llwlfufjmuu",
+		"xrpb": "kava1c0ju5vnwgpgxnrktfnkccuth9xqc68dcdpzpas",
+	}
+	bnbDeputiesStrings map[string]string = map[string]string{
+		"bnb":  "bnb1jh7uv2rm6339yue8k4mj9406k3509kr4wt5nxn",
+		"btcb": "bnb1xz3xqf4p2ygrw9lhp5g5df4ep4nd20vsywnmpr",
+		"busd": "bnb10zq89008gmedc6rrwzdfukjk94swynd7dl97w8",
+		"xrpb": "bnb15jzuvvg2kf0fka3fl2c8rx0kc3g6wkmvsqhgnh",
+	}
+)
+
 // SwapIDCmd returns a command to calculate a bep3 swap ID for binance and kava chains.
 func SwapIDCmd(cdc *codec.Codec) *cobra.Command {
 
-	var deputyAddrStr string
-
-	mainnetKavaDeputy, err := sdk.AccAddressFromBech32("kava1r4v2zdhdalfj2ydazallqvrus9fkphmglhn6u6")
-	if err != nil {
-		panic(err.Error())
+	kavaDeputies := map[string]sdk.AccAddress{}
+	for k, v := range kavaDeputiesStrings {
+		kavaDeputies[k] = mustKavaAccAddressFromBech32(v)
 	}
-	mainnetBnbDeputy, err := binance.AccAddressFromBech32("bnb1jh7uv2rm6339yue8k4mj9406k3509kr4wt5nxn")
-	if err != nil {
-		panic(err.Error())
+	bnbDeputies := map[string]binance.AccAddress{}
+	for k, v := range bnbDeputiesStrings {
+		bnbDeputies[k] = mustBnbAccAddressFromBech32(v)
 	}
 
 	cmd := &cobra.Command{
-		Use:   "swap-id random_number_hash original_sender_address",
+		Use:   "swap-id random_number_hash original_sender_address deputy_addres_or_denom",
 		Short: "Calculate binance and kava swap IDs given swap details.",
-		Long: `A swap's ID is: hash(swap.RandomNumberHash, swap.Sender, swap.SenderOtherChain)
+		Long: fmt.Sprintf(`A swap's ID is: hash(swap.RandomNumberHash, swap.Sender, swap.SenderOtherChain)
 One of the senders is always the deputy's address, the other is the user who initiated the first swap (the original sender).
-Corresponding swaps on each chain have the same addresses but switched order.
+Corresponding swaps on each chain have the same RandomNumberHash, but switched address order.
 		
-By default kava-3 mainnet deputy addresses are used, but can be overridden with a flag.
+The deputy can be one of %v to automatically use the mainnet deputy addresses, or an arbitrary address.
 The original sender and deputy address cannot be from the same chain.
-`,
-		Example: "swap-id 464105c245199d02a4289475b8b231f3f73918b6f0fdad898825186950d46f36 bnb10rr5f8m73rxgnz9afvnfn7fn9pwhfskem5kn0x --deputy kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
-		Args:    cobra.ExactArgs(2),
+`, getKeys(kavaDeputiesStrings)),
+		Example: "swap-id 464105c245199d02a4289475b8b231f3f73918b6f0fdad898825186950d46f36 bnb10rr5f8m73rxgnz9afvnfn7fn9pwhfskem5kn0x busd",
+		Args:    cobra.ExactArgs(3),
 		RunE: func(_ *cobra.Command, args []string) error {
-
-			// get deputy addresses
 
 			randomNumberHash, err := hex.DecodeString(args[0])
 			if err != nil {
@@ -61,56 +72,92 @@ The original sender and deputy address cannot be from the same chain.
 			}
 
 			// calculate swap IDs
+			depArg := args[2]
 			var swapIDKava, swapIDBnb []byte
 			if isKavaAddress {
-				if addressKava.Equals(mainnetKavaDeputy) {
-					return fmt.Errorf("original sender address cannot be mainnnet deputy address: %s", mainnetKavaDeputy)
+				// check sender isn't a deputy
+				for _, dep := range kavaDeputies {
+					if addressKava.Equals(dep) {
+						return fmt.Errorf("original sender address cannot be deputy address: %s", dep)
+					}
 				}
+				// pick deputy address
 				var bnbDeputy binance.AccAddress
-				if deputyAddrStr == "" {
-					bnbDeputy = mainnetBnbDeputy
-				} else {
-					bnbDeputy, err = binance.AccAddressFromBech32(deputyAddrStr)
+				bnbDeputy, ok := bnbDeputies[depArg]
+				if !ok {
+					bnbDeputy, err = binance.AccAddressFromBech32(depArg)
 					if err != nil {
 						return fmt.Errorf("can't unmarshal deputy address as bnb address (%s)", err)
 					}
 				}
+				// calc ids
 				swapIDKava = types.CalculateSwapID(randomNumberHash, addressKava, bnbDeputy.String())
 				swapIDBnb = binance.CalculateSwapID(randomNumberHash, bnbDeputy, addressKava.String())
 			} else {
-				if bytes.Equal(addressBnb, mainnetBnbDeputy) {
-					return fmt.Errorf("original sender address cannot be mainnet deputy address %s", mainnetBnbDeputy)
+				// check sender isn't a deputy
+				for _, dep := range bnbDeputies {
+					if bytes.Equal(addressBnb, dep) {
+						return fmt.Errorf("original sender address cannot be deputy address %s", dep)
+					}
 				}
+				// pick deputy address
 				var kavaDeputy sdk.AccAddress
-				if deputyAddrStr == "" {
-					kavaDeputy = mainnetKavaDeputy
-				} else {
-					kavaDeputy, err = sdk.AccAddressFromBech32(deputyAddrStr)
+				kavaDeputy, ok := kavaDeputies[depArg]
+				if !ok {
+					kavaDeputy, err = sdk.AccAddressFromBech32(depArg)
 					if err != nil {
 						return fmt.Errorf("can't unmarshal deputy address as kava address (%s)", err)
 					}
 				}
+				// calc ids
 				swapIDBnb = binance.CalculateSwapID(randomNumberHash, addressBnb, kavaDeputy.String())
 				swapIDKava = types.CalculateSwapID(randomNumberHash, kavaDeputy, addressBnb.String())
 			}
 
-			// print out result
-			result := struct {
-				KavaSwapID string
-				BnbSwapID  string
-			}{
-				KavaSwapID: hex.EncodeToString(swapIDKava),
-				BnbSwapID:  hex.EncodeToString(swapIDBnb),
-			}
-			bz, err := yaml.Marshal(result)
+			outString, err := formatResults(swapIDKava, swapIDBnb)
 			if err != nil {
 				return err
 			}
-			fmt.Println(string(bz))
+			fmt.Println(outString)
 			return nil
 		},
 	}
-	cmd.Flags().StringVarP(&deputyAddrStr, "deputy-address", "d", "", "the deputy address on the receiving chain")
 
 	return cmd
+}
+
+func formatResults(swapIDKava, swapIDBnb []byte) (string, error) {
+	result := struct {
+		KavaSwapID string `yaml:"kava_swap_id"`
+		BnbSwapID  string `yaml:"bnb_swap_id"`
+	}{
+		KavaSwapID: hex.EncodeToString(swapIDKava),
+		BnbSwapID:  hex.EncodeToString(swapIDBnb),
+	}
+	bz, err := yaml.Marshal(result)
+	return string(bz), err
+}
+
+func mustKavaAccAddressFromBech32(address string) sdk.AccAddress {
+	a, err := sdk.AccAddressFromBech32(address)
+	if err != nil {
+		panic(err)
+	}
+	return a
+}
+
+func mustBnbAccAddressFromBech32(address string) binance.AccAddress {
+	a, err := binance.AccAddressFromBech32(address)
+	if err != nil {
+		panic(err)
+	}
+	return a
+}
+
+func getKeys(m map[string]string) []string {
+	var keys []string
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }


### PR DESCRIPTION
`kvtool swap-id` users can now specify the deputy address using an asset string like "bnb", "xrpb", etc.
Overiding with custom address is still supported.

Examples:

```bash
> kvtool swap-id 88dad72574c5043adfac44b37e83277d279abe5f8e8b6033c3b657650e7cb88b bnb1e2sxy6r6zqued77j53ctxr6hqdv5ysl3yqpjzv busd
kava_swap_id: e1d31ea1ba7a4ef1ab94c07d4bb85622fa42ff1a7643cdc0af2fe83d9c415e08
bnb_swap_id: bece15a853cff8558ffaca8f745dcf9bd4103ab79985e9241ca56ce7ae88ceb2

```
```bash
> kvtool swap-id 88dad72574c5043adfac44b37e83277d279abe5f8e8b6033c3b657650e7cb88b bnb1e2sxy6r6zqued77j53ctxr6hqdv5ysl3yqpjzv kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
kava_swap_id: b71ec08811e9f3d99ac4be815d7b88c63878f1bbe8009819c0708e08f494bdd0
bnb_swap_id: 67ebfa571dc67948d91dc81c4f4c5f37f6542211203ac9a20d47d9aecb668ed2

```