### PR TITLE
Wait for tx confirmation (kvcli config)

### DIFF
--- a/config/templates/kava/master/initstate/.kvcli/config/config.toml
+++ b/config/templates/kava/master/initstate/.kvcli/config/config.toml
@@ -1,4 +1,4 @@
 keyring-backend = "test"
 chain-id = "kava-localnet"
 trust-node = true
-broadcast-mode = "async"
+broadcast-mode = "block"

--- a/config/templates/kava/v0.12/initstate/.kvcli/config/config.toml
+++ b/config/templates/kava/v0.12/initstate/.kvcli/config/config.toml
@@ -1,4 +1,4 @@
 keyring-backend = "test"
 chain-id = "kava-localnet"
 trust-node = true
-broadcast-mode = "async"
+broadcast-mode = "block"


### PR DESCRIPTION
Previously the kvcli within docker would send transactions and not wait for the response. This lead to confusion during acceptance as the PM would not catch tx failures.
This PR updates the config to make kvcli wait until the tx is in a block or not before returning so errors are reported.