### PR TITLE
support running testnet in detached mode

### DIFF
--- a/cmd/testnet.go
+++ b/cmd/testnet.go
@@ -124,12 +124,17 @@ available services: %s
 	genConfigCmd.Flags().BoolVar(&ibcFlag, "ibc", false, "flag for if ibc is enabled")
 	rootCmd.AddCommand(genConfigCmd)
 
+	var runDetachedFlag bool
+
 	upCmd := &cobra.Command{
 		Use:   "up",
 		Short: "A convenience command that runs `docker-compose up` on the generated config.",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cmd := []string{"docker-compose", "--file", filepath.Join(generatedConfigDir, "docker-compose.yaml"), "up"}
+			if runDetachedFlag {
+				cmd = append(cmd, "-d")
+			}
 			fmt.Println("running:", strings.Join(cmd, " "))
 			if err := replaceCurrentProcess(cmd...); err != nil {
 				return fmt.Errorf("could not run command: %v", err)
@@ -137,6 +142,7 @@ available services: %s
 			return nil
 		},
 	}
+	upCmd.Flags().BoolVarP(&runDetachedFlag, "detach", "d", false, "Detached mode: Run containers in the background.")
 	rootCmd.AddCommand(upCmd)
 
 	downCmd := &cobra.Command{


### PR DESCRIPTION
using the `-d` or `--detach` flag with `testnet up` command will spin up
the containers in the background.

```
$ kvtool testnet up --help
A convenience command that runs `docker-compose up` on the generated config.

Usage:
  kvtool testnet up [flags]

Flags:
  -d, --detach   Detached mode: Run containers in the background.
  -h, --help     help for up

Global Flags:
      --generated-dir string   output directory for the generated config (default "/Users/pirtle/projects/kava/kvtool/full_configs/generated")