### PR TITLE
add utility function for inspecting inflation

### DIFF
--- a/cmd/inflation.go
+++ b/cmd/inflation.go
@@ -9,47 +9,50 @@ import (
 	"github.com/kava-labs/kvtool/kavaclient"
 )
 
+var kavaGrpcUrl string
+
 func InflationRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "inflation [sub-command]",
 		Short: "Various utilities for checking realized inflation",
 	}
 
-	var kavaGrpcUrl string
 	cmd.PersistentFlags().StringVar(&kavaGrpcUrl, "node", "https://grpc.data.kava.io:443", "kava GRPC url to run queries against")
 
-	client, err := kavaclient.NewClient(kavaGrpcUrl)
-	if err != nil {
-		panic(fmt.Sprintf("failed to create kava grpc client: %s", err))
-	}
-
-	cmd.AddCommand(InflationSpotCheckAPY(client))
+	cmd.AddCommand(AverageInflation())
 
 	return cmd
 }
 
-func InflationSpotCheckAPY(k *kavaclient.Client) *cobra.Command {
+func AverageInflation() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "realized-apy [start-height] [end-height]",
-		Short: "Calculate the real inflation over a block range as an APY",
-		Long: `Looks at the number of coins minted over a range of blocks & extrapolates it to a yearly APY.
+		Use:   "avg [start-height] [end-height]",
+		Short: "Calculate the real inflation over a block range as an APR & APY",
+		Long: `Looks at the number of coins minted over a range of blocks and determines inflation.
+The amount minted is converted into an average APR (pre second period) & extrapolated to an APY.
 End height is optional, defaults to latest block. If start height is negative, it will subtract from end.`,
 		Args: cobra.MatchAll(cobra.MinimumNArgs(1), cobra.MaximumNArgs(2)),
 		Example: `calculate inflation over a block range:
-$ kvtool inflation realized-apy 2000000 2500000
+$ kvtool inflation avg 2000000 2500000
 
 calculate inflation from block 2M to present:
-$ kvtool inflation realized-apy 2000000
+$ kvtool inflation avg 2000000
 
 calculate inflation from last 10 blocks ("--" is necessary to interpret as an argument):
-$ kvtool inflation realized-apy -- -10
+$ kvtool inflation avg -- -10
 
 calculate inflation over the 1000 blocks before height 3000000:
-$ kvtool inflation realized-apy -- -1000 3000000
+$ kvtool inflation avg -- -1000 3000000
 `,
 		RunE: func(_ *cobra.Command, args []string) error {
 			var end int64
 			var err error
+			fmt.Printf("using endpoint %s\n", kavaGrpcUrl)
+			k, err := kavaclient.NewClient(kavaGrpcUrl)
+			if err != nil {
+				panic(fmt.Sprintf("failed to create kava grpc client: %s", err))
+			}
+
 			// default to latest block if no end provided
 			if len(args) == 1 {
 				latest, err := k.LatestBlock(5)
@@ -76,17 +79,12 @@ $ kvtool inflation realized-apy -- -1000 3000000
 				start = end + start
 			}
 
-			result, err := k.InflationApyOverBlocks(start, end)
+			result, err := k.InflationOverBlocks(start, end)
 			if err != nil {
 				return err
 			}
 
-			fmt.Printf(`inflation extrapolated as an APY
-start block: %d
-end block: %d
-total seconds passed: %f
-inflation apy (%d block avg): %s
-`, result.Start, result.End, result.SecondsPassed, result.End-result.Start, result.Inflation)
+			fmt.Println(result.String())
 
 			return nil
 		},

--- a/cmd/inflation.go
+++ b/cmd/inflation.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kava-labs/kvtool/kavaclient"
+)
+
+func InflationRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "inflation [sub-command]",
+		Short: "Various utilities for checking realized inflation",
+	}
+
+	var kavaGrpcUrl string
+	cmd.PersistentFlags().StringVar(&kavaGrpcUrl, "node", "https://grpc.data.kava.io:443", "kava GRPC url to run queries against")
+
+	client, err := kavaclient.NewClient(kavaGrpcUrl)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create kava grpc client: %s", err))
+	}
+
+	cmd.AddCommand(InflationSpotCheckAPY(client))
+
+	return cmd
+}
+
+func InflationSpotCheckAPY(k *kavaclient.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "realized-apy [start-height] [end-height]",
+		Short: "Calculate the real inflation over a block range as an APY",
+		Long: `Looks at the number of coins minted over a range of blocks & extrapolates it to a yearly APY.
+End height is optional, defaults to latest block. If start height is negative, it will subtract from end.`,
+		Args: cobra.MatchAll(cobra.MinimumNArgs(1), cobra.MaximumNArgs(2)),
+		Example: `calculate inflation over a block range:
+$ kvtool inflation realized-apy 2000000 2500000
+
+calculate inflation from block 2M to present:
+$ kvtool inflation realized-apy 2000000
+
+calculate inflation from last 10 blocks ("--" is necessary to interpret as an argument):
+$ kvtool inflation realized-apy -- -10
+
+calculate inflation over the 1000 blocks before height 3000000:
+$ kvtool inflation realized-apy -- -1000 3000000
+`,
+		RunE: func(_ *cobra.Command, args []string) error {
+			var end int64
+			var err error
+			// default to latest block if no end provided
+			if len(args) == 1 {
+				latest, err := k.LatestBlock(5)
+				if err != nil {
+					return fmt.Errorf("failed to fetch latest block: %s", err)
+				}
+				end = latest.Header.Height
+			} else {
+				end, err = strconv.ParseInt(args[1], 10, 64)
+				if err != nil {
+					return fmt.Errorf("failed to parse end block: %s", err)
+				}
+			}
+
+			start, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("failed to parse start block: %s", err)
+			}
+			if start == 0 {
+				return fmt.Errorf("start block cannot equal 0")
+			}
+			// interpret negative start values as a diff from end block.
+			if start < 0 {
+				start = end + start
+			}
+
+			result, err := k.InflationApyOverBlocks(start, end)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf(`inflation extrapolated as an APY
+start block: %d
+end block: %d
+total seconds passed: %f
+inflation apy (%d block avg): %s
+`, result.Start, result.End, result.SecondsPassed, result.End-result.Start, result.Inflation)
+
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ func Execute() error {
 
 	var cdc *codec.LegacyAmino = app.MakeEncodingConfig().Amino
 
+	rootCmd.AddCommand(InflationRootCmd())
 	rootCmd.AddCommand(MaccAddrCmd())
 	rootCmd.AddCommand(NodeKeysCmd(cdc))
 	rootCmd.AddCommand(SwapIDCmd(cdc))

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,13 @@ go 1.18
 require (
 	github.com/Jeffail/gabs/v2 v2.6.0
 	github.com/cosmos/cosmos-sdk v0.45.10
+	github.com/kava-labs/go-tools v0.0.0-20221224222255-39c4be283202
 	github.com/kava-labs/kava v0.21.0
 	github.com/otiai10/copy v1.6.0
 	github.com/spf13/cobra v1.6.0
 	github.com/tendermint/classic v0.0.0-20201012085102-0a11024b2668
 	github.com/tendermint/tendermint v0.34.24
+	google.golang.org/grpc v1.50.1
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -136,7 +138,6 @@ require (
 	golang.org/x/term v0.1.0 // indirect
 	golang.org/x/text v0.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20221014213838-99cd37c6964a // indirect
-	google.golang.org/grpc v1.50.1 // indirect
 	google.golang.org/protobuf v1.28.2-0.20220831092852-f930b1dc76e8 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect

--- a/go.sum
+++ b/go.sum
@@ -522,6 +522,8 @@ github.com/kava-labs/cosmos-sdk v0.45.9-kava.4 h1:nOsUMvY9qWvPyORBSV3k7G7D7Lc5Jj
 github.com/kava-labs/cosmos-sdk v0.45.9-kava.4/go.mod h1:Z5M4TX7PsHNHlF/1XanI2DIpORQ+Q/st7oaeufEjnvU=
 github.com/kava-labs/ethermint v0.14.0-kava-v20.1 h1:4ZM/SFPU7RLmioHICs9j+c4hzDZ9Rxb/b+Hs/guAyN4=
 github.com/kava-labs/ethermint v0.14.0-kava-v20.1/go.mod h1:+/TXGhi6XwF9B8h2NrYZCKrrv0+pC3RkpM0950lYyJg=
+github.com/kava-labs/go-tools v0.0.0-20221224222255-39c4be283202 h1:rmq2BLsVQm+k5pj/yv2+sh6vewDkWY0KmS865PpFigM=
+github.com/kava-labs/go-tools v0.0.0-20221224222255-39c4be283202/go.mod h1:jignPuIhdrfAf71cn0hJXA89BhAkUZnu01i/H1bZDGM=
 github.com/kava-labs/kava v0.21.0 h1:2KBVdSeSMfAdDyRuZq0nI9fBc2cr9bMSNAwbCuzJ2FI=
 github.com/kava-labs/kava v0.21.0/go.mod h1:3adeVmSpm8xejhI+v0qKZsLA8LNdMpkZSns1kXG9YiA=
 github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d h1:Z+RDyXzjKE0i2sTjZ/b1uxiGtPhFy34Ou/Tk0qwN0kM=

--- a/kavaclient/client.go
+++ b/kavaclient/client.go
@@ -1,0 +1,89 @@
+package kavaclient
+
+import (
+	"context"
+	"strconv"
+
+	"google.golang.org/grpc/metadata"
+
+	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	tmtypes "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	kavagrpc "github.com/kava-labs/go-tools/grpc"
+)
+
+type Client struct {
+	bankClient banktypes.QueryClient
+	tmService  tmservice.ServiceClient
+}
+
+func NewClient(grpcUrl string) (*Client, error) {
+	conn, err := kavagrpc.NewGrpcConnection(grpcUrl)
+	if err != nil {
+		return &Client{}, err
+	}
+
+	return &Client{
+		bankClient: banktypes.NewQueryClient(conn),
+		tmService:  tmservice.NewServiceClient(conn),
+	}, nil
+}
+
+func (c Client) GetBalance(address string, denom string, maxRetries int) (*sdk.Coin, error) {
+	res, err := c.bankClient.Balance(context.Background(), &banktypes.QueryBalanceRequest{
+		Address: address,
+		Denom:   denom,
+	})
+	if err != nil {
+		if maxRetries != 0 {
+			return c.GetBalance(address, denom, maxRetries-1)
+		}
+		return nil, err
+	}
+	return res.Balance, nil
+}
+
+func (c Client) Block(height int64, maxRetries int) (*tmtypes.Block, error) {
+	res, err := c.tmService.GetBlockByHeight(context.Background(), &tmservice.GetBlockByHeightRequest{
+		Height: height,
+	})
+	if err != nil {
+		if maxRetries != 0 {
+			return c.Block(height, maxRetries-1)
+		}
+		return nil, err
+	}
+	return res.Block, nil
+}
+
+func (c Client) LatestBlock(maxRetries int) (*tmtypes.Block, error) {
+	res, err := c.tmService.GetLatestBlock(context.Background(), &tmservice.GetLatestBlockRequest{})
+	if err != nil {
+		if maxRetries != 0 {
+			return c.LatestBlock(maxRetries - 1)
+		}
+		return nil, err
+	}
+	return res.Block, nil
+}
+
+func (c Client) Supply(height int64, maxRetries int) (sdk.Coin, error) {
+	res, err := c.bankClient.SupplyOf(ctxAtHeight(height), &banktypes.QuerySupplyOfRequest{
+		Denom: "ukava",
+	})
+	if err != nil {
+		if maxRetries != 0 {
+			return c.Supply(height, maxRetries-1)
+		}
+		return sdk.Coin{}, err
+	}
+	return res.Amount, nil
+}
+
+func ctxAtHeight(height int64) context.Context {
+	heightStr := strconv.FormatInt(height, 10)
+	return metadata.AppendToOutgoingContext(context.Background(), grpctypes.GRPCBlockHeightHeader, heightStr)
+}

--- a/kavaclient/inflation.go
+++ b/kavaclient/inflation.go
@@ -1,0 +1,67 @@
+package kavaclient
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const (
+	SecondsPerYear = 365 * 24 * 3600
+)
+
+type InflationResult struct {
+	Start         int64
+	End           int64
+	Inflation     *sdk.Dec
+	SecondsPassed float64
+}
+
+func (c *Client) InflationApyOverBlocks(start, end int64) (InflationResult, error) {
+	result := InflationResult{
+		Start: start,
+		End:   end,
+	}
+	retries := 5
+
+	// fetch start & end blocks for block time
+	startBlock, err := c.Block(start, retries)
+	if err != nil {
+		return result, fmt.Errorf("failed to fetch start block (height=%d): %s", start, err)
+	}
+	endBlock, err := c.Block(end, retries)
+	if err != nil {
+		return result, fmt.Errorf("failed to fetch end block (height=%d): %s", end, err)
+	}
+
+	// get total seconds passed
+	result.SecondsPassed = endBlock.Header.Time.Sub(startBlock.Header.Time).Seconds()
+
+	// get total supply @ start & end
+	supplyBefore, err := c.Supply(start, retries)
+	if err != nil {
+		return result, fmt.Errorf("failed to fetch total supply (start) at height %d: %s", start, err)
+	}
+	supplyAfter, err := c.Supply(end, retries)
+	if err != nil {
+		return result, fmt.Errorf("failed to fetch total supply (end) at height %d: %s", end, err)
+	}
+
+	// calculate inflation
+	result.Inflation, err = calculateInflationApy(supplyBefore.Amount, supplyAfter.Amount, result.SecondsPassed)
+	if err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func calculateInflationApy(beforeAmount, afterAmount sdk.Int, secondsPassed float64) (*sdk.Dec, error) {
+	// extrapolate kava produced in last block to an APY inflation rate
+	diff := afterAmount.Sub(beforeAmount).ToDec()
+	avg := afterAmount.Add(beforeAmount).ToDec().QuoInt64(2)
+	// doing the math this way to reduce error from a per-second approach
+	pow := sdk.NewDec(SecondsPerYear).Quo(sdk.MustNewDecFromStr(fmt.Sprintf("%f", secondsPassed))).RoundInt()
+	inflation := diff.Quo(avg).Add(sdk.OneDec()).Power(pow.Uint64()).Sub(sdk.OneDec())
+	return &inflation, nil
+}


### PR DESCRIPTION
```
$ kvtool inflation avg --help
Looks at the number of coins minted over a range of blocks and determines inflation.
The amount minted is converted into an average APR (pre second period) & extrapolated to an APY.
End height is optional, defaults to latest block. If start height is negative, it will subtract from end.

Usage:
  kvtool inflation avg [start-height] [end-height] [flags]

Examples:
calculate inflation over a block range:
$ kvtool inflation avg 2000000 2500000

calculate inflation from block 2M to present:
$ kvtool inflation avg 2000000

calculate inflation from last 10 blocks ("--" is necessary to interpret as an argument):
$ kvtool inflation avg -- -10

calculate inflation over the 1000 blocks before height 3000000:
$ kvtool inflation avg -- -1000 3000000


Flags:
  -h, --help   help for avg

Global Flags:
      --node string   kava GRPC url to run queries against (default "https://grpc.data.kava.io:443")
```