### PR TITLE
fix IBC for running in kava CI

### DIFF
--- a/cmd/testnet.go
+++ b/cmd/testnet.go
@@ -221,20 +221,6 @@ available services: %s
 			if ibcFlag {
 				fmt.Printf("Starting ibc connection between chains...\n")
 				time.Sleep(time.Second * 7)
-				restoreKeys1Cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("%s:%s", filepath.Join(generatedConfigDir, "hermes"), "/home/hermes/.hermes"), hermesImageTag, "keys", "restore", kavaChainId, "-n", "testkey", "-m", "very health column only surface project output absent outdoor siren reject era legend legal twelve setup roast lion rare tunnel devote style random food", "--hd-path", "m/44'/459'/0'/0/0")
-				restoreKeys1Cmd.Stdout = os.Stdout
-				restoreKeys1Cmd.Stderr = os.Stderr
-				if err := restoreKeys1Cmd.Run(); err != nil {
-					fmt.Println(err.Error())
-					return fmt.Errorf("[hermes] failed to restore keys on main chain")
-				}
-				restoreKeys2Cmd := exec.Command("docker", "run", "-v", fmt.Sprintf("%s:%s", filepath.Join(generatedConfigDir, "hermes"), "/home/hermes/.hermes"), hermesImageTag, "keys", "restore", ibcChainId, "-n", "testkey", "-m", "very health column only surface project output absent outdoor siren reject era legend legal twelve setup roast lion rare tunnel devote style random food", "--hd-path", "m/44'/459'/0'/0/0")
-				restoreKeys2Cmd.Stdout = os.Stdout
-				restoreKeys2Cmd.Stderr = os.Stderr
-				if err := restoreKeys2Cmd.Run(); err != nil {
-					fmt.Println(err.Error())
-					return fmt.Errorf("[hermes] failed to restore keys on ibc chain")
-				}
 				setupIbcPathCmd := exec.Command("docker", "run", "-v", fmt.Sprintf("%s:%s", filepath.Join(generatedConfigDir, "relayer"), "/home/relayer/.relayer"), "--network", "generated_default", relayerImageTag, "rly", "paths", "new", kavaChainId, ibcChainId, "transfer")
 				setupIbcPathCmd.Stdout = os.Stdout
 				setupIbcPathCmd.Stderr = os.Stderr
@@ -258,7 +244,6 @@ available services: %s
 				restartCmd := exec.Command("docker-compose", "--file", filepath.Join(generatedConfigDir, "docker-compose.yaml"), "up", "-d", "hermes-relayer")
 				restartCmd.Stdout = os.Stdout
 				restartCmd.Stderr = os.Stderr
-
 				err = restartCmd.Run()
 				if err != nil {
 					return err

--- a/config/generate/generate.go
+++ b/config/generate/generate.go
@@ -1,6 +1,7 @@
 package generate
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/otiai10/copy"
@@ -102,6 +103,11 @@ func GenerateGethConfig(generatedConfigDir string) error {
 
 func GenerateHermesRelayerConfig(generatedConfigDir string) error {
 	err := copy.Copy(filepath.Join(ConfigTemplatesDir, "hermes"), filepath.Join(generatedConfigDir, "hermes"))
+	if err != nil {
+		return err
+	}
+	// config.toml must be writable
+	err = os.Chmod(filepath.Join(generatedConfigDir, "hermes", "config.toml"), 0666)
 	return err
 }
 

--- a/config/generate/generate.go
+++ b/config/generate/generate.go
@@ -119,11 +119,10 @@ func AddHermesRelayerToNetwork(generatedConfigDir string) error {
 }
 
 func GenerateGoRelayerConfig(generatedConfigDir string) error {
-	err := copy.Copy(filepath.Join(ConfigTemplatesDir, "relayer"), filepath.Join(generatedConfigDir, "relayer"))
-	if err != nil {
-		return err
-	}
-	// config.yaml must be writable
-	err = os.Chmod(filepath.Join(generatedConfigDir, "relayer", "config", "config.yaml"), 0666)
+	err := copy.Copy(
+		filepath.Join(ConfigTemplatesDir, "relayer"),
+		filepath.Join(generatedConfigDir, "relayer"),
+		copy.Options{AddPermission: 0666},
+	)
 	return err
 }

--- a/config/generate/generate.go
+++ b/config/generate/generate.go
@@ -120,5 +120,10 @@ func AddHermesRelayerToNetwork(generatedConfigDir string) error {
 
 func GenerateGoRelayerConfig(generatedConfigDir string) error {
 	err := copy.Copy(filepath.Join(ConfigTemplatesDir, "relayer"), filepath.Join(generatedConfigDir, "relayer"))
+	if err != nil {
+		return err
+	}
+	// config.yaml must be writable
+	err = os.Chmod(filepath.Join(generatedConfigDir, "relayer", "config", "config.yaml"), 0666)
 	return err
 }

--- a/config/templates/hermes/keys/kavalocalnet_8888-1/keyring-test/testkey.json
+++ b/config/templates/hermes/keys/kavalocalnet_8888-1/keyring-test/testkey.json
@@ -1,0 +1,27 @@
+{
+  "public_key": "xpub6Go7odPf4c8YXBW13aBGVaE5VEFgLQGFBSq4An6QFu9MrdskyTixhVrpgi6gBnpXGejeySeoKnPoBnuZmsTuEC4vh8xY6xErc1VoaBSdtLx",
+  "private_key": "xprvA3omQ7rmEEaFJhRXwYeG8SHLwCRBvwYPpDuTNPgnhZcNyqYcRvQi9hYLqTijnJXFYwkw6MZZWfHisbBLE8o96nPALVjfriwki9DG4PNHAFS",
+  "account": "kava1ypjp0m04pyp73hwgtc0dgkx0e9rrydecm054da",
+  "address": [
+    32,
+    100,
+    23,
+    237,
+    245,
+    9,
+    3,
+    232,
+    221,
+    200,
+    94,
+    30,
+    212,
+    88,
+    207,
+    201,
+    70,
+    50,
+    55,
+    56
+  ]
+}

--- a/config/templates/hermes/keys/kavalocalnet_8889-2/keyring-test/testkey.json
+++ b/config/templates/hermes/keys/kavalocalnet_8889-2/keyring-test/testkey.json
@@ -1,0 +1,27 @@
+{
+  "public_key": "xpub6Go7odPf4c8YXBW13aBGVaE5VEFgLQGFBSq4An6QFu9MrdskyTixhVrpgi6gBnpXGejeySeoKnPoBnuZmsTuEC4vh8xY6xErc1VoaBSdtLx",
+  "private_key": "xprvA3omQ7rmEEaFJhRXwYeG8SHLwCRBvwYPpDuTNPgnhZcNyqYcRvQi9hYLqTijnJXFYwkw6MZZWfHisbBLE8o96nPALVjfriwki9DG4PNHAFS",
+  "account": "kava1ypjp0m04pyp73hwgtc0dgkx0e9rrydecm054da",
+  "address": [
+    32,
+    100,
+    23,
+    237,
+    245,
+    9,
+    3,
+    232,
+    221,
+    200,
+    94,
+    30,
+    212,
+    88,
+    207,
+    201,
+    70,
+    50,
+    55,
+    56
+  ]
+}


### PR DESCRIPTION
there were some docker user file permission problems in the CI. these changes ensure that the necessary files are writable by the docker container users.

additionally, it optimizes some of the ibc setup by hardcoding things like the relayer chain configs & key files.