### PR TITLE
close ibc race condition

### DIFF
--- a/cmd/testnet/bootstrap.go
+++ b/cmd/testnet/bootstrap.go
@@ -174,6 +174,11 @@ func validateBootstrapFlags() error {
 }
 
 func setupIbcChannelAndRelayer() error {
+	// wait for chain to be up and running before setting up ibc
+	if err := waitForBlock(1, 5*time.Second); err != nil {
+		return err
+	}
+
 	fmt.Printf("Starting ibc connection between chains...\n")
 	setupIbcPathCmd := exec.Command("docker", "run", "-v", fmt.Sprintf("%s:%s", generatedPath("relayer"), "/home/relayer/.relayer"), "--network", "generated_default", relayerImageTag, "rly", "paths", "new", kavaChainId, ibcChainId, "transfer")
 	setupIbcPathCmd.Stdout = os.Stdout

--- a/config/templates/ibcchain/master/docker-compose.yaml
+++ b/config/templates/ibcchain/master/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     ibcnode:
-        image: "kava/kava:master"
+        image: "kava/kava:v0.21.0"
         # use the default ports, but shift them when exposing to host so they dont conflict.
         ports:
             # open rpc port

--- a/config/templates/relayer/config/config.yaml
+++ b/config/templates/relayer/config/config.yaml
@@ -13,7 +13,7 @@ chains:
       account-prefix: kava
       keyring-backend: test
       gas-adjustment: 1.2
-      gas-prices: 0.001uatom
+      gas-prices: 0.01uatom
       min-gas-amount: 0
       debug: false
       timeout: 20s
@@ -28,8 +28,8 @@ chains:
       rpc-addr: http://kavanode:26657
       account-prefix: kava
       keyring-backend: test
-      gas-adjustment: 1.5
-      gas-prices: 0.001ukava
+      gas-adjustment: 1.2
+      gas-prices: 0.01ukava
       min-gas-amount: 0
       debug: false
       timeout: 20s


### PR DESCRIPTION
when docker starts up the relayer too fast the chains aren't yet ready for them. adds a WaitForBlock(1) to the ibc setup so it only starts opening a channel once the chains are ready for it.

additionally, affix the ibc docker tag & increase gas price in relayer.