### PR TITLE
update json-rpc ip to 0.0.0.0  & set max_gas

### DIFF
--- a/config/generate/genesis/generate-kava-genesis.sh
+++ b/config/generate/genesis/generate-kava-genesis.sh
@@ -90,6 +90,10 @@ sed -i '' 's/minimum-gas-prices = "0ukava"/minimum-gas-prices = "0.001ukava;1000
 # Disable pruning
 sed -i '' 's/pruning = "default"/pruning = "nothing"/g' $DATA/config/app.toml
 
+# Set EVM JSON-RPC starting IP addresses
+sed -i '' 's/address = "127.0.0.1:8545"/address = "0.0.0.0:8545"/g' $DATA/config/app.toml
+sed -i '' 's/ws-address = "127.0.0.1:8546"/ws-address = "0.0.0.0:8546"/g' $DATA/config/app.toml
+
 #######################
 ##### CLIENT.TOML #####
 #######################

--- a/config/generate/genesis/generate-kava-genesis.sh
+++ b/config/generate/genesis/generate-kava-genesis.sh
@@ -106,7 +106,6 @@ sed -i '' 's/chain-id = ""/chain-id = "'"$chainID"'"/g' $DATA/config/client.toml
 # lower default commit timeout
 sed -i '' 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $DATA/config/config.toml
 
-
 #########################
 ##### CONFIGURATION #####
 #########################
@@ -115,6 +114,12 @@ $BINARY config keyring-backend test
 
 # set broadcast-mode to block
 $BINARY config broadcast-mode block
+
+############################
+##### CONSENSUS PARAMS #####
+############################
+# set maximum gas allowed per block
+jq '.consensus_params.block.max_gas = "2000000"' $DATA/config/genesis.json | sponge $DATA/config/genesis.json
 
 ###########################
 ##### SETUP ADDRESSES #####

--- a/config/templates/kava/master/initstate/.kava/config/app.toml
+++ b/config/templates/kava/master/initstate/.kava/config/app.toml
@@ -275,10 +275,10 @@ max-tx-gas-wanted = 0
 enable = true
 
 # Address defines the EVM RPC HTTP server address to bind to.
-address = "127.0.0.1:8545"
+address = "0.0.0.0:8545"
 
 # Address defines the EVM WebSocket server address to bind to.
-ws-address = "127.0.0.1:8546"
+ws-address = "0.0.0.0:8546"
 
 # API defines a list of JSON-RPC namespaces that should be enabled
 # Example: "eth,txpool,personal,net,debug,web3"

--- a/config/templates/kava/master/initstate/.kava/config/genesis.json
+++ b/config/templates/kava/master/initstate/.kava/config/genesis.json
@@ -1,5 +1,5 @@
 {
-  "genesis_time": "2023-04-04T18:34:39.584381Z",
+  "genesis_time": "2023-04-04T19:58:59.612979Z",
   "chain_id": "kavalocalnet_8888-1",
   "initial_height": "1",
   "consensus_params": {

--- a/config/templates/kava/master/initstate/.kava/config/genesis.json
+++ b/config/templates/kava/master/initstate/.kava/config/genesis.json
@@ -1,11 +1,11 @@
 {
-  "genesis_time": "2023-04-04T19:58:59.612979Z",
+  "genesis_time": "2023-04-04T20:33:24.509589Z",
   "chain_id": "kavalocalnet_8888-1",
   "initial_height": "1",
   "consensus_params": {
     "block": {
       "max_bytes": "22020096",
-      "max_gas": "-1",
+      "max_gas": "2000000",
       "time_iota_ms": "1000"
     },
     "evidence": {


### PR DESCRIPTION
new default app.json launches the evm's json-rpc server on 127.0.0.1 which breaks the docker port exposure.

this changes the ips back to 0.0.0.0 so the evm is properly exposed.

additionally, sets max_gas consensus params to 2M (not -1, which is no longer supported by our antehandlers)