### PR TITLE
add cmd estimating block height at a given time

### DIFF
--- a/cmd/estimate-block.go
+++ b/cmd/estimate-block.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kava-labs/kvtool/kavaclient"
+)
+
+const estimateBlockTimeFormat = "2006-01-02T15:04"
+
+func EstimateBlockHeightCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "estimate-block-height [desired-time]",
+		Short: "Estimate height at a given time",
+		Long: `Provides an estimate of the block height at a desired time based on various blocktime averages.
+Time must be in UTC. Format times like YYYY-MM-DDThh:mm.
+`,
+		Args: cobra.ExactArgs(1),
+		Example: `Estimate height on May 22, 2050 at 15:00 UTC:
+$ kvtool estimate-block-height 2050-05-22T15:00
+`,
+		RunE: func(_ *cobra.Command, args []string) error {
+			numRetries := 5
+
+			fmt.Printf("using endpoint %s\n", kavaGrpcUrl)
+			k, err := kavaclient.NewClient(kavaGrpcUrl)
+			if err != nil {
+				return fmt.Errorf("failed to create kava grpc client: %s", err)
+			}
+
+			now := time.Now()
+			desiredTimeUTC, err := time.Parse(estimateBlockTimeFormat, args[0])
+			if err != nil {
+				return fmt.Errorf("failed to parse time '%s': %s", args[0], err)
+			}
+			if desiredTimeUTC.Before(now) {
+				return fmt.Errorf("desired estimation time (%s) has already happened. are you using UTC?", desiredTimeUTC)
+			}
+
+			secondsUntilThen := desiredTimeUTC.Sub(now).Seconds()
+			fmt.Printf(
+				"estimating height at time %s (%d seconds from now):\n",
+				desiredTimeUTC.Format(estimateBlockTimeFormat),
+				int(math.Round(secondsUntilThen)),
+			)
+
+			blockAverages := []int64{10000, 50000, 75000, 100000}
+
+			currentBlock, err := k.LatestBlock(numRetries)
+			if err != nil {
+				return fmt.Errorf("failed to fetch latest block: %s", err)
+			}
+			currentHeight := currentBlock.Header.Height
+
+			for _, numBlocks := range blockAverages {
+				height := currentHeight - numBlocks
+				startBlock, err := k.Block(height, numRetries)
+				if err != nil {
+					return fmt.Errorf("failed to fetch block %d: %s", height, err)
+				}
+
+				secondsPassed := currentBlock.Header.Time.Sub(startBlock.Header.Time).Seconds()
+				blocksPerSec := float64(numBlocks) / secondsPassed
+				blocksUntilThen := int64(math.Round(blocksPerSec * secondsUntilThen))
+				heightAtTime := currentHeight + blocksUntilThen
+				fmt.Printf("%8d block avg: height = %d (%d blocks @ %f bps, %.1fh avg)\n", numBlocks, heightAtTime, blocksUntilThen, blocksPerSec, secondsPassed/3600)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.PersistentFlags().StringVar(&kavaGrpcUrl, "node", "https://grpc.data.kava.io:443", "kava GRPC url to run queries against")
+
+	return cmd
+}

--- a/cmd/inflation.go
+++ b/cmd/inflation.go
@@ -9,8 +9,6 @@ import (
 	"github.com/kava-labs/kvtool/kavaclient"
 )
 
-var kavaGrpcUrl string
-
 func InflationRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "inflation [sub-command]",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,8 @@ import (
 	"github.com/kava-labs/kvtool/cmd/testnet"
 )
 
+var kavaGrpcUrl string
+
 var rootCmd = &cobra.Command{
 	Use:   "kvtool",
 	Short: "Dev tools for working with the kava blockchain.",
@@ -23,6 +25,7 @@ func Execute() error {
 
 	var cdc *codec.LegacyAmino = app.MakeEncodingConfig().Amino
 
+	rootCmd.AddCommand(EstimateBlockHeightCmd())
 	rootCmd.AddCommand(InflationRootCmd())
 	rootCmd.AddCommand(MaccAddrCmd())
 	rootCmd.AddCommand(NodeKeysCmd(cdc))


### PR DESCRIPTION
```
❯ kvtool estimate-block-height --help
Provides an estimate of the block height at a desired time based on various blocktime averages.
Time must be in UTC. Format times like YYYY-MM-DDThh:mm.

Usage:
  kvtool estimate-block-height [desired-time] [flags]

Examples:
Estimate height on May 22, 2050 at 15:00 UTC:
$ kvtool estimate-block-height 2050-05-22T15:00


Flags:
  -h, --help          help for estimate-block-height
      --node string   kava GRPC url to run queries against (default "https://grpc.data.kava.io:443")
```

Example Output:
```
❯ kvtool estimate-block-height 2023-05-17T15:00
using endpoint https://grpc.data.kava.io:443
estimating height at time 2023-05-17T15:00 (763992 seconds from now):
   10000 block avg: height = 4831939 (118521 blocks @ 0.155134 bps, 17.9h avg)
   50000 block avg: height = 4832178 (118760 blocks @ 0.155447 bps, 89.3h avg)
   75000 block avg: height = 4832287 (118869 blocks @ 0.155589 bps, 133.9h avg)
  100000 block avg: height = 4832509 (119091 blocks @ 0.155880 bps, 178.2h avg)
```