### PR TITLE
fix: Ensure chain upgrades when specified

### DIFF
--- a/cmd/testnet/docker.go
+++ b/cmd/testnet/docker.go
@@ -1,0 +1,188 @@
+package testnet
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// mustReachHeightOrLog waits for the specified block height to be reached on the
+// specified chain, or prints container logs and exits the program with an error.
+func mustReachHeightOrLog(
+	n int64,
+	timeout time.Duration,
+	chainDockerServiceName string,
+) error {
+	err := waitForBlock(n, timeout, chainDockerServiceName)
+	// **No** error, successfully reached target block
+	if err == nil {
+		return nil
+	}
+
+	fmt.Printf("error waiting for %s block: %s\n", chainDockerServiceName, err)
+
+	containerID, err := getContainerID(chainDockerServiceName)
+	if err != nil {
+		return fmt.Errorf("failed getting container ID for logs: %w", err)
+	}
+
+	logs, err := getContainerLogs(chainDockerServiceName)
+	if err != nil {
+		return fmt.Errorf("failed getting container logs: %w", err)
+	}
+
+	// Dumps the container logs here, it shouldn't be too much since
+	// it will fail either immediately or after 20 seconds of
+	// retries.
+	fmt.Printf("%s (container ID %s) logs shown below:\n", chainDockerServiceName, containerID)
+	fmt.Printf("========================================\n")
+	fmt.Println(logs)
+
+	// Custom error handling, no return of error to cobra
+	os.Exit(1)
+
+	return nil
+}
+
+// checkContainerStatus returns an error if the specified container is not
+// running.
+func checkContainerStatus(
+	chainDockerServiceName string,
+) error {
+	// check state of container
+	out, err := exec.Command(
+		"docker",
+		"compose",
+		"-f",
+		generatedPath("docker-compose.yaml"),
+		"ps",
+		"-a", // all including exited
+		"--format",
+		"{{.State}}",
+		chainDockerServiceName,
+	).Output()
+	if err != nil {
+		stderr := ""
+		if errors.Is(err, &exec.ExitError{}) {
+			stderr = string(err.(*exec.ExitError).Stderr)
+		}
+
+		return fmt.Errorf("error checking container state, %s: %w", stderr, err)
+	}
+
+	containerState := strings.TrimSpace(string(out))
+
+	if containerState != "running" {
+		return fmt.Errorf(
+			"%s container is not running, current state is \"%s\"",
+			chainDockerServiceName,
+			containerState,
+		)
+	}
+
+	return nil
+}
+
+func getContainerID(
+	chainDockerServiceName string,
+) (string, error) {
+	out, err := exec.Command(
+		"docker",
+		"compose",
+		"-f",
+		generatedPath("docker-compose.yaml"),
+		"ps",
+		"-a", // all including exited
+		"--format",
+		"{{.ID}}",
+		chainDockerServiceName,
+	).Output()
+	if err != nil {
+		stderr := ""
+
+		exitErr, ok := err.(*exec.ExitError)
+		if ok {
+			stderr = string(exitErr.Stderr)
+		}
+
+		return "", fmt.Errorf("failed compose ps \"%s\": %w", stderr, err)
+	}
+
+	containerID := strings.TrimSpace(string(out))
+	return containerID, nil
+}
+
+func getContainerLogs(
+	chainDockerServiceName string,
+) (string, error) {
+	containerID, err := getContainerID(chainDockerServiceName)
+	if err != nil {
+		return "", fmt.Errorf("failed getting container ID: %w", err)
+	}
+
+	out, err := exec.Command(
+		"docker",
+		"logs",
+		containerID,
+	).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to get container logs: %w", err)
+	}
+
+	return string(out), nil
+}
+
+// getContainerLogsChannel returns a channel that streams logs from a container
+func getContainerLogsChannel(
+	ctx context.Context,
+	chainDockerServiceName string,
+) (<-chan string, error) {
+	containerID, err := getContainerID(chainDockerServiceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed getting container ID: %w", err)
+	}
+
+	// Run with CommandContext so it automatically cancels when the context is
+	// done.
+	cmd := exec.CommandContext(
+		ctx,
+		"docker",
+		"logs",
+		"-f",
+		containerID,
+	)
+	cmdReader, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get command stdout pipe: %w", err)
+	}
+
+	scanner := bufio.NewScanner(cmdReader)
+	out := make(chan string)
+
+	go func(scanner *bufio.Scanner, out chan string) {
+		for scanner.Scan() {
+			// Check if the context is done, if so close the channel and return.
+			// Don't need to manually stop the cmd since we use CommandContext()
+			select {
+			case <-ctx.Done():
+				close(out)
+				return
+			default:
+				out <- scanner.Text()
+			}
+		}
+	}(scanner, out)
+
+	// Start process, but don't wait for it to finish since it follows logs.
+	// Don't use .Run() as it will block until it completes, causing a hang.
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to run docker logs -f %s: %w", containerID, err)
+	}
+
+	return out, nil
+}

--- a/cmd/testnet/service_names.go
+++ b/cmd/testnet/service_names.go
@@ -1,0 +1,3 @@
+package testnet
+
+const DockerServiceKavaNode = "kavanode"

--- a/config/generate/genesis/evmutil.accounts.json
+++ b/config/generate/genesis/evmutil.accounts.json
@@ -1,0 +1,22 @@
+[
+  {
+    "address": "kava1ypjp0m04pyp73hwgtc0dgkx0e9rrydecm054da",
+    "balance": "700000000000"
+  },
+  {
+    "address": "kava1vlpsrmdyuywvaqrv7rx6xga224sqfwz3fyfhwq",
+    "balance": "300000000000"
+  },
+  {
+    "address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
+    "balance": "200000000000"
+  },
+  {
+    "address": "kava1g33w0mh4mjllhaj3y4dcwkwquxgwrma9ga5t94",
+    "balance": "400000000000"
+  },
+  {
+    "address": "kava1kla4wl0ccv7u85cemvs3y987hqk0afcv7vue84",
+    "balance": "400000000000"
+  }
+]

--- a/config/generate/genesis/generate-kava-genesis.sh
+++ b/config/generate/genesis/generate-kava-genesis.sh
@@ -332,7 +332,7 @@ set-app-state evm.accounts
 # setup eip712 allowed messages
 set-app-state evm.params.eip712_allowed_msgs
 # setup enabled precompiles
-set-app-state evm.params.enabled_precompiles
+# set-app-state evm.params.enabled_precompiles
 
 # x/evmutil: enable evm -> sdk conversion pair
 jq '.app_state.evmutil.params.enabled_conversion_pairs = [
@@ -341,6 +341,9 @@ jq '.app_state.evmutil.params.enabled_conversion_pairs = [
     "denom": "erc20/tether/usdt"
   }
 ]' $DATA/config/genesis.json | sponge $DATA/config/genesis.json
+
+# fractional balances
+set-app-state evmutil.accounts
 
 # x/evmutil: enable sdk -> evm conversion pair
 # HARD is enabled for kava's e2e tests (must be first in this list.)

--- a/config/generate/genesis/generate-kava-genesis.sh
+++ b/config/generate/genesis/generate-kava-genesis.sh
@@ -331,7 +331,7 @@ jq '.app_state.evm.params.chain_config.cancun_block = null' $DATA/config/genesis
 set-app-state evm.accounts
 # setup eip712 allowed messages
 set-app-state evm.params.eip712_allowed_msgs
-# setup enabled precompiles
+# setup enabled precompiles - not yet in master
 # set-app-state evm.params.enabled_precompiles
 
 # x/evmutil: enable evm -> sdk conversion pair

--- a/config/templates/kava/master/initstate/.kava/config/genesis.json
+++ b/config/templates/kava/master/initstate/.kava/config/genesis.json
@@ -1,5 +1,5 @@
 {
-  "genesis_time": "2024-05-09T23:34:23.453894Z",
+  "genesis_time": "2024-07-12T00:27:25.024459Z",
   "chain_id": "kavalocalnet_8888-1",
   "initial_height": "1",
   "consensus_params": {
@@ -805,6 +805,15 @@
             {
               "denom": "xrpb",
               "amount": "10000000000000000"
+            }
+          ]
+        },
+        {
+          "address": "kava1w9vxuke5dz6hyza2j932qgmxltnfxwl78u920k",
+          "coins": [
+            {
+              "denom": "ukava",
+              "amount": "2"
             }
           ]
         }
@@ -2212,14 +2221,32 @@
             "nested_types": []
           }
         ],
-        "allow_unprotected_txs": false,
-        "enabled_precompiles": [
-          "0x9000000000000000000000000000000000000001"
-        ]
+        "allow_unprotected_txs": false
       }
     },
     "evmutil": {
-      "accounts": [],
+      "accounts": [
+        {
+          "address": "kava1ypjp0m04pyp73hwgtc0dgkx0e9rrydecm054da",
+          "balance": "700000000000"
+        },
+        {
+          "address": "kava1vlpsrmdyuywvaqrv7rx6xga224sqfwz3fyfhwq",
+          "balance": "300000000000"
+        },
+        {
+          "address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
+          "balance": "200000000000"
+        },
+        {
+          "address": "kava1g33w0mh4mjllhaj3y4dcwkwquxgwrma9ga5t94",
+          "balance": "400000000000"
+        },
+        {
+          "address": "kava1kla4wl0ccv7u85cemvs3y987hqk0afcv7vue84",
+          "balance": "400000000000"
+        }
+      ],
       "params": {
         "enabled_conversion_pairs": [
           {
@@ -2287,7 +2314,7 @@
                 }
               }
             ],
-            "memo": "461d9761df5db0a112407ca8a82f1774ef2dbaa3@10.0.0.176:26656",
+            "memo": "461d9761df5db0a112407ca8a82f1774ef2dbaa3@192.168.1.137:26656",
             "timeout_height": "0",
             "extension_options": [],
             "non_critical_extension_options": []
@@ -2316,7 +2343,7 @@
             "tip": null
           },
           "signatures": [
-            "LDBw6Fd0rajEB9vKbdPIVc5TIfTbljifnL3Kta6mZ6E27bVO6NRK03g86qMfDD+4UXuikPnqm0wm3E/8yiWNdg=="
+            "qHfPN/7kgyuJeypt/EUbWbrEbE8tTM0NMgC0Z/W3GSsUlfXUyFfXkKY8u48e7hijJK/S+ESKUuLh+Vao69xiFg=="
           ]
         }
       ]
@@ -3219,6 +3246,10 @@
       "in_flight_packets": {}
     },
     "params": null,
+    "precisebank": {
+      "balances": [],
+      "remainder": "0"
+    },
     "pricefeed": {
       "params": {
         "markets": [


### PR DESCRIPTION
- Retries upgrade proposal vote, as cosmos sdk v0.47.0 removed broadcast mode block. With the "sync" mode, it only runs CheckTx and may not be in a block in subsequent calls (causes account number mismatch error).
- Ensure chain actually halted by monitoring chain logs. This was a source of vague errors when the upgrade proposal was not correctly applied then continued to make blocks. The binary replacement would still continue and cause errors due to a missing upgrade.
  - Note: Ideally we replace the use of exec.Command() for docker with the [docker go client](https://pkg.go.dev/github.com/docker/docker/client)
- Add evmutil balances to genesis for testing purposes. 