### PR TITLE
fix: read stdout AND stderr from docker logs

### DIFF
--- a/cmd/testnet/docker.go
+++ b/cmd/testnet/docker.go
@@ -156,7 +156,10 @@ func getContainerLogsChannel(
 		"-f",
 		containerID,
 	)
+	// pipe all stdout to a ReadCloser we can scan
 	cmdReader, err := cmd.StdoutPipe()
+	// redirect all stderr output to stdout
+	cmd.Stderr = cmd.Stdout
 	if err != nil {
 		return nil, fmt.Errorf("failed to get command stdout pipe: %w", err)
 	}


### PR DESCRIPTION
some versions of kava seem to output their logs to stderr. when performing an automated upgrade, kvtool checks for chain halt by scanning the docker logs. when these logs occur on stderr, the halt is never seen and the attempted upgrade fails due to timeout.

NOT ANYMORE! 😄 