### PR TITLE
chore(docker-compose): Remove obsolete version

### DIFF
--- a/config/templates/binance/v0.8/docker-compose.yaml
+++ b/config/templates/binance/v0.8/docker-compose.yaml
@@ -1,4 +1,3 @@
-
 services:
   bnbnode:
     build: "./binance"

--- a/config/templates/binance/v0.8/docker-compose.yaml
+++ b/config/templates/binance/v0.8/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 
 services:
   bnbnode:

--- a/config/templates/deputy/docker-compose.yaml
+++ b/config/templates/deputy/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   bnb_deputy:
     image: kava/deputy:v0.4.0

--- a/config/templates/geth/docker-compose.yaml
+++ b/config/templates/geth/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     gethnode:
         image: "ethereum/client-go:latest"

--- a/config/templates/ibcchain/master/docker-compose.yaml
+++ b/config/templates/ibcchain/master/docker-compose.yaml
@@ -1,4 +1,3 @@
-
 services:
   ibcnode:
     image: "kava/kava:v0.25.0-goleveldb"

--- a/config/templates/ibcchain/master/docker-compose.yaml
+++ b/config/templates/ibcchain/master/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 
 services:
   ibcnode:

--- a/config/templates/kava/master/docker-compose.yaml
+++ b/config/templates/kava/master/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     kavanode:
         image: "kava/kava:${KAVA_TAG:-master-goleveldb}"

--- a/config/templates/kava/pruning-node/docker-compose.yaml
+++ b/config/templates/kava/pruning-node/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     kava-pruning:
         depends_on:

--- a/config/templates/kava/v0.10/docker-compose.yaml
+++ b/config/templates/kava/v0.10/docker-compose.yaml
@@ -1,4 +1,3 @@
-
 services:
     kavanode:
         image: kava/kava:${KAVA_TAG:-v0.10.0}

--- a/config/templates/kava/v0.10/docker-compose.yaml
+++ b/config/templates/kava/v0.10/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
     kavanode:

--- a/config/templates/kava/v0.12/docker-compose.yaml
+++ b/config/templates/kava/v0.12/docker-compose.yaml
@@ -1,4 +1,3 @@
-
 services:
     kavanode:
         image: "kava/kava:${KAVA_TAG:-v0.12.0}"

--- a/config/templates/kava/v0.12/docker-compose.yaml
+++ b/config/templates/kava/v0.12/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
     kavanode:

--- a/config/templates/kava/v0.14/docker-compose.yaml
+++ b/config/templates/kava/v0.14/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 
 services:
   kavanode:

--- a/config/templates/kava/v0.14/docker-compose.yaml
+++ b/config/templates/kava/v0.14/docker-compose.yaml
@@ -1,4 +1,3 @@
-
 services:
   kavanode:
     image: "kava/kava:${KAVA_TAG:-v0.14.1}"

--- a/config/templates/kava/v0.15/docker-compose.yaml
+++ b/config/templates/kava/v0.15/docker-compose.yaml
@@ -1,4 +1,3 @@
-
 services:
     kavanode:
         image: "kava/kava:${KAVA_TAG:-v0.15.1}"

--- a/config/templates/kava/v0.15/docker-compose.yaml
+++ b/config/templates/kava/v0.15/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
     kavanode:

--- a/config/templates/kava/v0.16/docker-compose.yaml
+++ b/config/templates/kava/v0.16/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     kavanode:
         image: "kava/kava:${KAVA_TAG:-v0.16}"

--- a/config/templates/kava/v0.17/docker-compose.yaml
+++ b/config/templates/kava/v0.17/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   kavanode:
     image: "kava/kava:${KAVA_TAG:-v0.17.1}"

--- a/config/templates/kava/v0.18/docker-compose.yaml
+++ b/config/templates/kava/v0.18/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   kavanode:
     image: "kava/kava:${KAVA_TAG:-v0.18.2}"

--- a/config/templates/kava/v0.19/docker-compose.yaml
+++ b/config/templates/kava/v0.19/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   kavanode:
     image: "kava/kava:${KAVA_TAG:-v0.19.2}"

--- a/config/templates/kava/v0.21/docker-compose.yaml
+++ b/config/templates/kava/v0.21/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     kavanode:
         image: "kava/kava:${KAVA_TAG:-v0.21.0}"

--- a/config/templates/kava/v0.23/docker-compose.yaml
+++ b/config/templates/kava/v0.23/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     kavanode:
         image: "kava/kava:${KAVA_TAG:-v0.23.1}"

--- a/config/templates/kava/v0.24/docker-compose.yaml
+++ b/config/templates/kava/v0.24/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     kavanode:
         image: "kava/kava:${KAVA_TAG:-v0.24.0}"

--- a/config/templates/kava/v0.25/docker-compose.yaml
+++ b/config/templates/kava/v0.25/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     kavanode:
         image: "kava/kava:${KAVA_TAG:-v0.25.0}"

--- a/config/templates/kava/v0.26/docker-compose.yaml
+++ b/config/templates/kava/v0.26/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     kavanode:
         image: "kava/kava:${KAVA_TAG:-v0.26.0-goleveldb}"

--- a/config/templates/oracle/docker-compose.yaml
+++ b/config/templates/oracle/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   oracle:
     image: kava/kava-tools:someting

--- a/config/templates/relayer/docker-compose.yaml
+++ b/config/templates/relayer/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   relayer:
     image: kava/relayer:v2.4.2

--- a/contrib/valval/docker-compose.yaml
+++ b/contrib/valval/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   kava-1:
     image: "kava/kava:${KAVA_IMAGE_TAG:-master}"


### PR DESCRIPTION
This removes the version from docker compose files as it is obsolete and only servers to produce warnings.

In addition, the valval docker-compose.yml was renamed to docker-compose.yaml in order to match existing file name patterns.